### PR TITLE
Merge `aws-cli-node` into `node`

### DIFF
--- a/aws-cli-node/push.sh
+++ b/aws-cli-node/push.sh
@@ -1,3 +1,0 @@
-docker login -u justincasedev
-docker build -t justincasetech/aws-cli-node .
-docker push justincasetech/aws-cli-node


### PR DESCRIPTION
Summary
* Revert addition of manual push script
  * While you can always inspect all docker layers, I would prefer using release tags as a single source of truth of image definitions, for the sake of reproducibility and self-documentation
* Rename the newly added image to `node:12.14.1-aws-cli-stretch`
  * In place of the previous `aws-cli-node:12.14.1` / `aws-cli-node:12.14.1-aws-cli-stretch`
  * Enforce a nomenclature of `{main-software}:{version}-[{base/supporting-software}...]`
