### PR TITLE
feat: update `justincasetech/node`

### DIFF
--- a/aws-cli-node/Dockerfile
+++ b/aws-cli-node/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:12.16.2-stretch
+FROM node:14.16.1-stretch
 
-RUN set -e;\
- apt-get update;\
- apt-get install -y python3-pip=9.0.1-2+deb9u1;\
- pip3 install awscli==1.18.39
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.1.38.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+RUN rm -rf ./aws ./awscliv2.zip


### PR DESCRIPTION
## TL;DR
- `justincasetech/node` のバージョン更新
- `node` のバージョンを `14.16.1` へ変更
- `aws-cli` のバージョンを `2.1.38` へ変更 (現在の最新版)

## マージ後の対応
- `docker push justincasetech/node:14.16.1-aws-cli-stretch` を実行